### PR TITLE
Add cloudfront distribution for reticulum assets

### DIFF
--- a/terraform/live/dev/ret/terraform.tfvars
+++ b/terraform/live/dev/ret/terraform.tfvars
@@ -12,6 +12,7 @@ terragrunt = {
   }
 }
 
+ret_domain = "reticulum.io"
 ret_instance_type = "m3.xlarge"
 ret_http_port = 4000
 janus_wss_port = 443

--- a/terraform/modules/base/main.tf
+++ b/terraform/modules/base/main.tf
@@ -15,3 +15,12 @@ resource "aws_iam_policy" "base-policy" {
   policy = "${var.shared["base_policy"]}"
 }
 
+resource "random_id" "bucket-identifier" {
+  byte_length = 8
+}
+
+# Logs bucket
+resource "aws_s3_bucket" "logs-bucket" {
+  bucket = "logs.reticulum-${var.shared["env"]}-${random_id.bucket-identifier.hex}"
+  acl = "private"
+}

--- a/terraform/modules/base/output.tf
+++ b/terraform/modules/base/output.tf
@@ -5,3 +5,7 @@ output "base_policy_arn" {
 output "mr_ssh_key_id" {
   value = "${aws_key_pair.mr-ssh-key.id}"
 }
+
+output "logs_bucket_id" {
+  value ="${aws_s3_bucket.logs-bucket.id}"
+}

--- a/terraform/modules/ret/main.tf
+++ b/terraform/modules/ret/main.tf
@@ -1,6 +1,7 @@
 variable "shared" { type = "map" }
 terraform { backend "s3" {} }
 provider "aws" { region = "${var.shared["region"]}", version = "~> 0.1" }
+provider "aws" { alias = "east", region = "us-east-1", version = "~> 0.1" }
 data "aws_availability_zones" "all" {}
 
 data "terraform_remote_state" "vpc" { backend = "s3", config = { key = "vpc/terraform.tfstate", bucket = "${var.shared["state_bucket"]}", region = "${var.shared["region"]}", dynamodb_table = "${var.shared["dynamodb_table"]}", encrypt = "true" } }
@@ -10,11 +11,17 @@ data "terraform_remote_state" "hab" { backend = "s3", config = { key = "hab/terr
 data "terraform_remote_state" "ret-db" { backend = "s3", config = { key = "ret-db/terraform.tfstate", bucket = "${var.shared["state_bucket"]}", region = "${var.shared["region"]}", dynamodb_table = "${var.shared["dynamodb_table"]}", encrypt = "true" } }
 
 data "aws_route53_zone" "reticulum-zone" {
-  name = "reticulum.io."
+  name = "${var.ret_domain}."
 }
 
 data "aws_acm_certificate" "ret-alb-listener-cert" {
-  domain = "*.reticulum.io"
+  domain = "*.${var.ret_domain}"
+  statuses = ["ISSUED"]
+}
+
+data "aws_acm_certificate" "ret-alb-listener-cert-east" {
+  provider = "aws.east"
+  domain = "*.${var.ret_domain}"
   statuses = ["ISSUED"]
 }
 
@@ -287,4 +294,70 @@ resource "aws_autoscaling_group" "ret" {
   tag { key = "env", value = "${var.shared["env"]}", propagate_at_launch = true }
   tag { key = "host-type", value = "${var.shared["env"]}-ret", propagate_at_launch = true }
   tag { key = "hab-ring", value = "${var.shared["env"]}", propagate_at_launch = true }
+}
+
+resource "aws_cloudfront_distribution" "ret-assets" {
+  enabled = true
+
+  origin {
+    origin_id = "reticulum-${var.shared["env"]}-assets"
+    domain_name = "${aws_alb.ret-alb.dns_name}"
+
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_ssl_protocols = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_protocol_policy = "https-only"
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  logging_config {
+    bucket = "${data.terraform_remote_state.base.logs_bucket_id}.s3.amazonaws.com"
+    prefix = "cloudfront/ret-assets"
+    include_cookies = false
+  }
+
+  aliases = ["assets-#{var.shared["env"]}.${var.ret_domain}"]
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD"]
+    target_origin_id = "reticulum-${var.shared["env"]}-assets"
+   
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    viewer_protocol_policy = "https-only"
+    min_ttl = 0
+    default_ttl = 3600
+    max_ttl = 3600
+  }
+
+  price_class = "PriceClass_All"
+  
+  viewer_certificate {
+    acm_certificate_arn = "${data.aws_acm_certificate.ret-alb-listener-cert-east.arn}"
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+}
+
+resource "aws_route53_record" "ret-assets-dns" {
+  zone_id = "${data.aws_route53_zone.reticulum-zone.zone_id}"
+  name = "assets-${var.shared["env"]}.${data.aws_route53_zone.reticulum-zone.name}"
+  type = "A"
+
+  alias {
+    name = "${aws_cloudfront_distribution.ret-assets.domain_name}"
+    zone_id = "${aws_cloudfront_distribution.ret-assets.hosted_zone_id}"
+    evaluate_target_health = false
+  }
 }

--- a/terraform/modules/ret/main.tf
+++ b/terraform/modules/ret/main.tf
@@ -323,7 +323,7 @@ resource "aws_cloudfront_distribution" "ret-assets" {
     include_cookies = false
   }
 
-  aliases = ["assets-#{var.shared["env"]}.${var.ret_domain}"]
+  aliases = ["assets-${var.shared["env"]}.${var.ret_domain}"]
 
   default_cache_behavior {
     allowed_methods = ["GET", "HEAD", "OPTIONS"]

--- a/terraform/modules/ret/main.tf
+++ b/terraform/modules/ret/main.tf
@@ -301,7 +301,7 @@ resource "aws_cloudfront_distribution" "ret-assets" {
 
   origin {
     origin_id = "reticulum-${var.shared["env"]}-assets"
-    domain_name = "${aws_alb.ret-alb.dns_name}"
+    domain_name = "${var.shared["env"]}.${var.ret_domain}"
 
     custom_origin_config {
       http_port = 80

--- a/terraform/modules/ret/vars.tf
+++ b/terraform/modules/ret/vars.tf
@@ -29,3 +29,7 @@ variable "min_ret_servers" {
 variable "max_ret_servers" {
   description = "Maximum number of reticulum servers to run"
 }
+
+variable "ret_domain" {
+  description = "Domain name being used for reticulum server (ex reticulum.io)"
+}


### PR DESCRIPTION
For https://github.com/mozilla/reticulum/issues/4

adds CF endpoint for reticulum assets that is backed by the server as origin