### PR TITLE
Log Janus events to SQLite DB

### DIFF
--- a/ansible/roles/ret/templates/janus-gateway.toml.j2
+++ b/ansible/roles/ret/templates/janus-gateway.toml.j2
@@ -32,3 +32,6 @@ secure_port = 8443
 admin_http = "yes"
 admin_port = 7000
 admin_ip = "EC2_PRIVATE_IP"
+
+[events]
+broadcast = "yes"

--- a/plans/janus-gateway/habitat/config/janus.eventhandler.sqlite.cfg
+++ b/plans/janus-gateway/habitat/config/janus.eventhandler.sqlite.cfg
@@ -1,0 +1,4 @@
+[general]
+enabled = yes
+db_path = {{ pkg.svc_var_path }}/events.db
+events = 65503 # everything except 32 = JANUS_EVENT_TYPE_MEDIA

--- a/plans/janus-gateway/habitat/default.toml
+++ b/plans/janus-gateway/habitat/default.toml
@@ -163,7 +163,7 @@ admin_wss = "no"
 #admin_ws_acl = "127.,192.168.0."
 
 [events]
-broadcast = "no"
+broadcast = "yes"
 stats_period = 5
 
 # List of disabled events

--- a/plans/janus-gateway/habitat/plan.sh
+++ b/plans/janus-gateway/habitat/plan.sh
@@ -89,7 +89,7 @@ do_build() {
   cp "$(pkg_path_for core/pkg-config)/share/aclocal/pkg.m4" "$(pkg_path_for core/automake)/share/aclocal/"
 
   sh autogen.sh
-  sh configure --prefix="$pkg_prefix"
+  sh configure --prefix="$pkg_prefix" --disable-all-plugins --disable-all-handlers
 
   make
 


### PR DESCRIPTION
They'll go in /hab/svc/janus-gateway/var/events.db.

The only events that get logged right now are events that you would characterize as "connection state updates", e.g. someone attached a plugin handle, someone negotiated a WebRTC connection, someone disconnected their websocket. So the database size should remain small under any reasonable load and we shouldn't have to worry about rotating it or truncating it or anything at the moment.

I bumped the Janus gateway version, because we needed recent changes to the event handler API. There shouldn't be any visible changes though.